### PR TITLE
Add support for validating one workflow

### DIFF
--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -19,6 +19,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ericcornelissen/ghasum/internal/cache"
@@ -52,10 +54,23 @@ func cmdVerify(argv []string) error {
 		return errors.Join(errCache, err)
 	}
 
+	stat, err := os.Stat(target)
+	if err != nil {
+		return errors.Join(errUnexpected, err)
+	}
+
+	var workflow string
+	if !stat.IsDir() {
+		repo := path.Join(path.Dir(target), "..", "..")
+		workflow, _ = filepath.Rel(repo, target)
+		target = repo
+	}
+
 	cfg := ghasum.Config{
-		Repo:  os.DirFS(target),
-		Path:  target,
-		Cache: c,
+		Repo:     os.DirFS(target),
+		Path:     target,
+		Workflow: workflow,
+		Cache:    c,
 	}
 
 	problems, err := ghasum.Verify(&cfg)
@@ -83,6 +98,12 @@ func helpVerify() string {
 Verify the Actions in the target against the stored checksums. If no target is
 provided it will default to the current working directory. If the checksums do
 not match this command will error with a non-zero exit code.
+
+The target can be either a directory or a file. If it is a directory it must be
+the root of a repository (that is, it should contain the .github directory). In
+this case checksums will be verified for every workflow in the repository. If it
+is a file it must be a workflow file in a repository. In this case checksums
+will be verified only for the given workflow.
 
 If ghasum is not yet initialized this command errors (see "ghasum help init").
 

--- a/internal/gha/gha.go
+++ b/internal/gha/gha.go
@@ -37,8 +37,8 @@ type GitHubAction struct {
 // WorkflowsPath is the relative path to the GitHub Actions workflow directory.
 var WorkflowsPath = path.Join(".github", "workflows")
 
-// RepoActions extracts the GitHub RepoActions used in the repository at the
-// given file system hierarchy.
+// RepoActions extracts the GitHub Actions used in the repository at the given
+// file system hierarchy.
 func RepoActions(repo fs.FS) ([]GitHubAction, error) {
 	rawWorkflows, err := workflowsInRepo(repo)
 	if err != nil {
@@ -56,6 +56,21 @@ func RepoActions(repo fs.FS) ([]GitHubAction, error) {
 	}
 
 	actions, err := actionsInWorkflows(workflows)
+	if err != nil {
+		return nil, err
+	}
+
+	return actions, nil
+}
+
+// WorkflowActions extracts the GitHub Actions used in the provided workflow.
+func WorkflowActions(rawWorkflow []byte) ([]GitHubAction, error) {
+	w, err := parseWorkflow(rawWorkflow)
+	if err != nil {
+		return nil, err
+	}
+
+	actions, err := actionsInWorkflows([]workflow{w})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gha/gha_test.go
+++ b/internal/gha/gha_test.go
@@ -15,6 +15,7 @@
 package gha
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -142,5 +143,58 @@ func TestRealisticRepository(t *testing.T) {
 		if !slices.Contains(got, want) {
 			t.Errorf("Wanted value missing %v", want)
 		}
+	}
+}
+
+func TestWorkflowActions(t *testing.T) {
+	t.Parallel()
+
+	type TestCase struct {
+		workflow []byte
+		wantErr  bool
+	}
+
+	testCases := []TestCase{
+		{
+			workflow: []byte(workflowWithNoJobs),
+			wantErr:  false,
+		},
+		{
+			workflow: []byte(workflowWithJobNoSteps),
+			wantErr:  false,
+		},
+		{
+			workflow: []byte(workflowWithJobWithSteps),
+			wantErr:  false,
+		},
+		{
+			workflow: []byte(workflowWithJobsWithSteps),
+			wantErr:  false,
+		},
+		{
+			workflow: []byte(workflowWithNestedActions),
+			wantErr:  false,
+		},
+		{
+			workflow: []byte(workflowWithSyntaxError),
+			wantErr:  true,
+		},
+		{
+			workflow: []byte(workflowWithInvalidUses),
+			wantErr:  true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			_, err := WorkflowActions(tc.workflow)
+			if err == nil && tc.wantErr {
+				t.Error("Unexpected success")
+			} else if err != nil && !tc.wantErr {
+				t.Error("Unexpected failure")
+			}
+		})
 	}
 }

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -38,6 +38,11 @@ type (
 		// non-read file system operation.
 		Path string
 
+		// Workflow is the file path (relative to Path) of the workflow that is the
+		// subject of the operation. If this has the zero value all workflows in the
+		// Repo will collectively be the subject of the operation instead.
+		Workflow string
+
 		// Cache is the cache that should be used for the operation.
 		Cache cache.Cache
 	}
@@ -61,7 +66,12 @@ func Initialize(cfg *Config) error {
 		}
 	}()
 
-	checksums, err := compute(cfg, checksum.BestAlgo)
+	actions, err := find(cfg)
+	if err != nil {
+		return err
+	}
+
+	checksums, err := compute(cfg, actions, checksum.BestAlgo)
 	if err != nil {
 		return err
 	}
@@ -104,7 +114,12 @@ func Update(cfg *Config) error {
 		return err
 	}
 
-	checksums, err := compute(cfg, checksum.BestAlgo)
+	actions, err := find(cfg)
+	if err != nil {
+		return err
+	}
+
+	checksums, err := compute(cfg, actions, checksum.BestAlgo)
 	if err != nil {
 		return err
 	}
@@ -145,7 +160,12 @@ func Verify(cfg *Config) ([]Problem, error) {
 		return nil, err
 	}
 
-	fresh, err := compute(cfg, checksum.Sha256)
+	actions, err := find(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	fresh, err := compute(cfg, actions, checksum.Sha256)
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/verify/error.txtar
+++ b/testdata/verify/error.txtar
@@ -1,15 +1,42 @@
-# Repo without actions
+# Repo that doesn't use GitHub Actions
 ! exec ghasum verify no-actions/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
-# Uninitialized repo with Actions
+# Uninitialized repo that uses GitHub Actions
 ! exec ghasum verify uninitialized/
 ! stdout 'Ok'
 stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
+# Directory not found
+! exec ghasum verify directory-not-found/
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'no such file or directory'
+
+# Workflow not found
+! exec ghasum verify initialized/.github/workflows/not-found.yml
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'no such file or directory'
+
+-- initialized/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
+-- initialized/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
 -- no-actions/.keep --
 This file exists to create a repo that does not use Github Actions.
 -- uninitialized/.github/workflows/workflow.yml --

--- a/testdata/verify/problems.txtar
+++ b/testdata/verify/problems.txtar
@@ -1,11 +1,23 @@
-# Checksum mismatch
+# Checksum mismatch - Repo
 ! exec ghasum verify -cache .cache/ mismatch/
 stdout .
 ! stdout 'Ok'
 ! stderr .
 
-# Checksum missing
+# Checksum mismatch - Workflow
+! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml
+stdout .
+! stdout 'Ok'
+! stderr .
+
+# Checksum missing - Repo
 ! exec ghasum verify -cache .cache/ missing/
+stdout .
+! stdout 'Ok'
+! stderr .
+
+# Checksum missing - Workflow
+! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml
 stdout .
 ! stdout 'Ok'
 ! stderr .
@@ -13,7 +25,7 @@ stdout .
 -- mismatch/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@v4 xCHyD2IBscJ1q4pfZ3pVXntv0HgGM8tQrG2h3ZHQeuk=
+actions/checkout@v4 oJp2lqI5zRjHTtu2vQ9/rfcqiYqRAnhqMjwnw/ss4x0=
 actions/setup-go@v5 /ChzMZC1jsCd/aTotskAS7hl1cX9/M5XsV7mJHCMuME=
 -- mismatch/.github/workflows/workflow.yml --
 name: Example workflow
@@ -35,7 +47,7 @@ jobs:
 -- missing/.github/workflows/gha.sum --
 version 1
 
-actions/checkout@v4 NQDx6JqrrKyfeOkbY1jy5XFTgfP3P/r9G9l17ENtfBA=
+actions/checkout@v4 oJp2lqI5zRjHTtu2vQ9/rfcqiYqRAnhqMjwnw/ss4x0=
 -- missing/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]

--- a/testdata/verify/success.txtar
+++ b/testdata/verify/success.txtar
@@ -1,10 +1,20 @@
-# Checksums match exactly
+# Checksums match exactly - Repo
 exec ghasum verify -cache .cache/ up-to-date/
 stdout 'Ok'
 ! stderr .
 
-# Redundant checksum stored
+# Checksums match exactly - Workflow
+exec ghasum verify -cache .cache/ up-to-date/.github/workflows/workflow.yml
+stdout 'Ok'
+! stderr .
+
+# Redundant checksum stored - Repo
 exec ghasum verify -cache .cache/ redundant/
+stdout 'Ok'
+! stderr .
+
+# Redundant checksum stored - Workflow
+exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml
 stdout 'Ok'
 ! stderr .
 


### PR DESCRIPTION
Closes #1

## Summary

Extend the `ghasum verify` command with the ability to verify a single workflow. In particular, when the provided target is a file instead of a directory it will treat it as if it's a workflow file inside a repo and use the repo as target and limit the verification scope to only that workflow.