### PR TITLE
Continuously validate `ghasum` checksums

### DIFF
--- a/.github/workflows/ghasum.yml
+++ b/.github/workflows/ghasum.yml
@@ -1,0 +1,22 @@
+name: ghasum
+on:
+  pull_request: ~
+  push:
+    branches:
+    - main
+
+permissions: read-all
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: Verify checksums
+      run: go run ./cmd/ghasum verify -cache /home/runner/work/_actions


### PR DESCRIPTION
Relates to #2, #4, #9, #15

## Summary

Add a GitHub Actions workflows that continuously validates the ghasum checksums for this project. This workflow is triggered whenever code has been changed and validates all actions used in all workflows. This will only result in a failed job when there is a problem, it won't prevent running any action with a checksum mismatch.

This is implemented for two reasons. First it's another kind of dogfeeding to gain experience with the tool. Second it's aimed towards enforcing updating the checksums when Dependabot creates a Pull Request to update an action (which wasn't the case for #15).

Because of the limitation noted above this is NOT implemented to avoid running potentially compromised actions. The intend is to start doing that when #2 is implemented.