### PR TITLE
Unlock `gha.sum` if an error occurs during updating

### DIFF
--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -101,6 +101,7 @@ func Update(cfg *Config) error {
 	}
 
 	defer func() {
+		_ = unlock(cfg.Path)
 		_ = file.Close()
 	}()
 


### PR DESCRIPTION
## Summary

Fix a bug where using `ghasum update` could result in a locked gha.sum file when an unexpected error occurred. While not fatal - it could be fixed by re-initializing or successfully updating - it is inconvenient and buggy. This fixes the problem by always unlocking the file in the deferred function that closes the file handle as well.