### PR TITLE
Let `ghasum update` fail if the gha.sum file is corrupt

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -36,7 +36,7 @@ not possible to process shall exit immediately (it means the file may be edited
 by another process leading to an inconsistent state).
 
 If the file lock is obtained, the process shall first read it and parse it
-partially to extract the sumfile version. If this fails the process shall exit
+completely to extract the sumfile version. If this fails the process shall exit
 immediately. Else it shall recompute checksums for all actions used in the
 repository (see [Computing Checksums]) using the best available hashing
 algorithm. It shall then store them in a sumfile (see [Storing Checksums]) using

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -37,11 +37,18 @@ by another process leading to an inconsistent state).
 
 If the file lock is obtained, the process shall first read it and parse it
 completely to extract the sumfile version. If this fails the process shall exit
-immediately. Else it shall recompute checksums for all actions used in the
-repository (see [Computing Checksums]) using the best available hashing
-algorithm. It shall then store them in a sumfile (see [Storing Checksums]) using
-the same sumfile version as before and releases the lock. As a consequence, this
-adds missing and removes redundant checksums from the sumfile.
+immediately unless the `-force` flag is used (see details below). Else it shall
+recompute checksums for all actions used in the repository (see [Computing
+Checksums]) using the best available hashing algorithm. It shall then store them
+in a sumfile (see [Storing Checksums]) using the same sumfile version as before
+and releases the lock. As a consequence, this adds missing and removes redundant
+checksums from the sumfile.
+
+With the `-force` flag the process will ignore errors in the sumfile and fix
+those while updating. If the sumfile version can still be determined from
+sumfile it will be used, otherwise the latest available version is used instead.
+This option is disabled by default to avoid unknowingly fixing syntax errors in
+a sumfile, which is an important fact to know about from a security perspective.
 
 This process does not verify any of the checksums currently in the sumfile.
 

--- a/cmd/ghasum/main.go
+++ b/cmd/ghasum/main.go
@@ -46,6 +46,7 @@ const (
 
 const (
 	flagNameCache   = "cache"
+	flagNameForce   = "force"
 	flagNameNoCache = "no-cache"
 )
 

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -27,6 +27,7 @@ import (
 func cmdUpdate(argv []string) error {
 	var (
 		flags       = flag.NewFlagSet(cmdNameUpdate, flag.ContinueOnError)
+		flagForce   = flags.Bool(flagNameForce, false, "")
 		flagCache   = flags.String(flagNameCache, "", "")
 		flagNoCache = flags.Bool(flagNameNoCache, false, "")
 	)
@@ -57,7 +58,7 @@ func cmdUpdate(argv []string) error {
 		Cache: c,
 	}
 
-	if err := ghasum.Update(&cfg); err != nil {
+	if err := ghasum.Update(&cfg, *flagForce); err != nil {
 		return errors.Join(errUnexpected, err)
 	}
 
@@ -79,6 +80,9 @@ The available flags are:
         The location of the cache directory. This is where ghasum stores and
         looks up repositories it needs.
         Defaults to a directory named .ghasum in the user's home directory.
+    -force
+        Force updating the gha.sum file, ignoring errors and fixing them in the
+        process.
     -no-cache
         Disable the use of the cache. Makes the -cache flag ineffective.`
 }

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -94,7 +94,7 @@ func Initialize(cfg *Config) error {
 
 // Update will update the ghasum checksums for the repository specified in the
 // given configuration.
-func Update(cfg *Config) error {
+func Update(cfg *Config, force bool) error {
 	file, err := open(cfg.Path)
 	if err != nil {
 		return err
@@ -111,7 +111,13 @@ func Update(cfg *Config) error {
 
 	version, err := version(raw)
 	if err != nil {
-		return err
+		if !force {
+			return errors.Join(ErrSumfileRead, err)
+		}
+
+		if errors.Is(err, sumfile.ErrHeaders) || errors.Is(err, sumfile.ErrVersion) {
+			version = sumfile.VersionLatest
+		}
 	}
 
 	actions, err := find(cfg)

--- a/internal/sumfile/errors.go
+++ b/internal/sumfile/errors.go
@@ -28,4 +28,8 @@ var (
 
 	// ErrSyntax is the error when a checksum file has a syntax error.
 	ErrSyntax = errors.New("syntax error")
+
+	// ErrVersion is the error when the version is invalid or missing from the
+	// checksum file.
+	ErrVersion = errors.New("version error")
 )

--- a/testdata/update/error.txtar
+++ b/testdata/update/error.txtar
@@ -1,3 +1,9 @@
+# Invalid sumfile
+! exec ghasum update invalid/
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'could not decode the checksum file'
+
 # Repo without actions
 ! exec ghasum update no-actions/
 ! stdout 'Ok'
@@ -10,6 +16,10 @@ stderr 'ghasum has not yet been initialized'
 stderr 'an unexpected error occurred'
 stderr 'ghasum has not yet been initialized'
 
+-- invalid/.github/workflows/gha.sum --
+version 1
+
+this-action/is-missing@a-checksum
 -- no-actions/.keep --
 This file exists to create a repo that does not use Github Actions.
 -- uninitialized/.github/workflows/workflow.yml --

--- a/testdata/update/force.txtar
+++ b/testdata/update/force.txtar
@@ -1,0 +1,112 @@
+# Error in entries
+exec ghasum update -cache .cache/ -force entries/
+stdout 'Ok'
+! stderr .
+cmp entries/.github/workflows/gha.sum .want/gha.sum
+
+# Error in headers
+exec ghasum update -cache .cache/ -force headers/
+stdout 'Ok'
+! stderr .
+cmp headers/.github/workflows/gha.sum .want/gha.sum
+
+# Error in version
+exec ghasum update -cache .cache/ -force nan-version/
+stdout 'Ok'
+! stderr .
+cmp nan-version/.github/workflows/gha.sum .want/gha.sum
+
+# Invalid version
+exec ghasum update -cache .cache/ -force invalid-version/
+stdout 'Ok'
+! stderr .
+cmp invalid-version/.github/workflows/gha.sum .want/gha.sum
+
+# Missing version
+exec ghasum update -cache .cache/ -force no-version/
+stdout 'Ok'
+! stderr .
+cmp no-version/.github/workflows/gha.sum .want/gha.sum
+
+-- entries/.github/workflows/gha.sum --
+version 1
+
+this-action/is-missing@a-checksum
+-- entries/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- headers/.github/workflows/gha.sum --
+invalid-header
+
+actions/checkout@v4.1.0 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+-- headers/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- invalid-version/.github/workflows/gha.sum --
+version 0
+
+actions/checkout@v4.1.0 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+-- invalid-version/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- nan-version/.github/workflows/gha.sum --
+version not-a-number
+
+actions/checkout@v4.1.0 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+-- nan-version/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- no-version/.github/workflows/gha.sum --
+version-header-missing 1
+
+actions/checkout@v4.1.0 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+-- no-version/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- .cache/actions/checkout/v4.1.1/.keep --
+This file exist to avoid fetching "actions/checkout@v4.1.1" and give the Action
+a unique checksum.
+-- .want/gha.sum --
+version 1
+
+actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=


### PR DESCRIPTION
Closes #7

## Summary

Update the internals for parsing the version from a gha.sum files in order to make `ghasum update` fail if the file is corrupted. This change is enforced going forward through the added test case.

**TODO:** Add option to `ghasum update` to force update `gha.sum` when it's corrupt.