### PR TITLE
Bump Go from 1.22.0 to 1.22.1

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.0-alpine3.19
+FROM docker.io/golang:1.22.1-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ghasum
 
-go 1.22.0
+go 1.22.1
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to [Audit / Vulnerabilities Job #39](https://github.com/ericcornelissen/ghasum/actions/runs/8165977594)

## Summary

Upgrade from Go 1.22.0 to 1.22.1 to receive 3 security-related updates that affect this codebase in 5 different ways across `internal/github` and `internal/ghasum`.

The relevant security IDs are: [GO-2024-2598](https://pkg.go.dev/vuln/GO-2024-2598), [GO-2024-2599](https://pkg.go.dev/vuln/GO-2024-2599), [GO-2024-2600](https://pkg.go.dev/vuln/GO-2024-2600).