### PR TITLE
Add support for validating one job in a workflow

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -59,13 +59,19 @@ error.
 
 If the checksum file exists the process shall read and parse it fully. If this
 fails the process shall exit immediately. Else it shall recompute the checksums
-(see [Computing Checksums]) for all actions in the repository using the same
-hashing algorithm as was used for the stored checksums. It shall then compare
-the computed checksums against the stored checksums.
+(see [Computing Checksums]) for all actions in the target using the same hashing
+algorithm as was used for the stored checksums. It shall compare the computed
+checksums against the stored checksums.
 
 If any of the checksums does not match or is missing the process shall exit with
 a non-zero exit code, for usability all values should be compared (and all
 mismatches reported) before exiting.
+
+The "target" can be one of a: a repository, a workflow, or a job. If the target
+is a repository, all actions used in all jobs in all workflows in the repository
+will be considered. If the target is a workflow, only actions used in all jobs
+in the workflow will be considered. If the target is a job, only actions used in
+the job will be considered.
 
 Redundant checksums are ignored by this process.
 

--- a/internal/gha/actions.go
+++ b/internal/gha/actions.go
@@ -71,12 +71,11 @@ func workflowsInRepo(repo fs.FS) ([][]byte, error) {
 			return nil
 		}
 
-		file, err := repo.Open(entryPath)
+		data, err := workflowInRepo(repo, entryPath)
 		if err != nil {
-			return fmt.Errorf("could not open workflow at %q: %v", entryPath, err)
+			return err
 		}
 
-		data, _ := io.ReadAll(file)
 		workflows = append(workflows, data)
 		return nil
 	}
@@ -86,4 +85,14 @@ func workflowsInRepo(repo fs.FS) ([][]byte, error) {
 	}
 
 	return workflows, nil
+}
+
+func workflowInRepo(repo fs.FS, path string) ([]byte, error) {
+	file, err := repo.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open workflow at %q: %v", path, err)
+	}
+
+	data, _ := io.ReadAll(file)
+	return data, nil
 }

--- a/internal/ghasum/atoms.go
+++ b/internal/ghasum/atoms.go
@@ -17,7 +17,6 @@ package ghasum
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -85,17 +84,10 @@ func find(cfg *Config) ([]gha.GitHubAction, error) {
 	if cfg.Workflow == "" {
 		actions, err = gha.RepoActions(cfg.Repo)
 	} else {
-		var (
-			data []byte
-			file fs.File
-		)
-
-		file, err = cfg.Repo.Open(cfg.Workflow)
-		if err == nil {
-			data, err = io.ReadAll(file)
-			if err == nil {
-				actions, err = gha.WorkflowActions(data)
-			}
+		if cfg.Job == "" {
+			actions, err = gha.WorkflowActions(cfg.Repo, cfg.Workflow)
+		} else {
+			actions, err = gha.JobActions(cfg.Repo, cfg.Workflow, cfg.Job)
 		}
 	}
 

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -43,6 +43,12 @@ type (
 		// Repo will collectively be the subject of the operation instead.
 		Workflow string
 
+		// Job is the id (also known as key) of the job that is the subject of the
+		// operation. If this has the zero value all jobs in the Workflow will
+		// collectively be the subject of the operation instead. (If Workflow has
+		// the zero value this value is ignored.)
+		Job string
+
 		// Cache is the cache that should be used for the operation.
 		Cache cache.Cache
 	}

--- a/testdata/verify/error.txtar
+++ b/testdata/verify/error.txtar
@@ -22,6 +22,12 @@ stderr 'no such file or directory'
 stderr 'an unexpected error occurred'
 stderr 'no such file or directory'
 
+# Job not found
+! exec ghasum verify initialized/.github/workflows/workflow.yml:not-found
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'job "not-found" not found in workflow ".github/workflows/workflow.yml"'
+
 -- initialized/.github/workflows/gha.sum --
 version 1
 

--- a/testdata/verify/problems.txtar
+++ b/testdata/verify/problems.txtar
@@ -10,6 +10,12 @@ stdout .
 ! stdout 'Ok'
 ! stderr .
 
+# Checksum mismatch - Job
+! exec ghasum verify -cache .cache/ mismatch/.github/workflows/workflow.yml:example
+stdout .
+! stdout 'Ok'
+! stderr .
+
 # Checksum missing - Repo
 ! exec ghasum verify -cache .cache/ missing/
 stdout .
@@ -18,6 +24,12 @@ stdout .
 
 # Checksum missing - Workflow
 ! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml
+stdout .
+! stdout 'Ok'
+! stderr .
+
+# Checksum missing - Job
+! exec ghasum verify -cache .cache/ missing/.github/workflows/workflow.yml:example
 stdout .
 ! stdout 'Ok'
 ! stderr .

--- a/testdata/verify/success.txtar
+++ b/testdata/verify/success.txtar
@@ -8,6 +8,11 @@ exec ghasum verify -cache .cache/ up-to-date/.github/workflows/workflow.yml
 stdout 'Ok'
 ! stderr .
 
+# Checksums match exactly - Job
+exec ghasum verify -cache .cache/ up-to-date/.github/workflows/workflow.yml:example
+stdout 'Ok'
+! stderr .
+
 # Redundant checksum stored - Repo
 exec ghasum verify -cache .cache/ redundant/
 stdout 'Ok'
@@ -17,6 +22,26 @@ stdout 'Ok'
 exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml
 stdout 'Ok'
 ! stderr .
+
+# Redundant checksum stored - Job
+exec ghasum verify -cache .cache/ redundant/.github/workflows/workflow.yml:example
+stdout 'Ok'
+! stderr .
+
+# Checksums match partially - Workflow
+exec ghasum verify -cache .cache/ partial/.github/workflows/valid.yml
+stdout 'Ok'
+! stderr .
+
+# Checksums match partially - Job
+exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml:valid
+stdout 'Ok'
+! stderr .
+
+# Checksums match partially - Sanity check
+! exec ghasum verify -cache .cache/ partial/
+! exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml
+! exec ghasum verify -cache .cache/ partial/.github/workflows/invalid.yml:invalid
 
 -- up-to-date/.github/workflows/gha.sum --
 version 1
@@ -66,6 +91,47 @@ jobs:
         go-version-file: go.mod
     - name: This step does not use an action
       run: Echo 'hello world!'
+-- partial/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
+actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM7c=
+-- partial/.github/workflows/valid.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+    - name: This step does not use an action
+      run: Echo 'hello world!'
+-- partial/.github/workflows/invalid.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  valid:
+    name: valid
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+    - name: This step does not use an action
+      run: Echo 'hello world!'
+  invalid:
+    name: invalid
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@main
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
 -- .cache/actions/checkout/main/.keep --
 This file exist to avoid fetching "actions/checkout@main" and give the Action a
 unique checksum.


### PR DESCRIPTION
Closes #2 
Relates to #1, #16

## Summary

Extend the `ghasum verify` command with the ability to verify a single job in a workflow. In particular, when the provided target ends with `:suffix` the suffix will be stripped and used as the job id/key, the rest of the target is then treated as the workflow to verify. This will result in the verification scope being limited to only that job (in that workflow).