### PR TITLE
Correct `uses:` value parsing with respect to `@`

### DIFF
--- a/internal/gha/parse.go
+++ b/internal/gha/parse.go
@@ -50,7 +50,7 @@ func parseUses(uses string) (GitHubAction, error) {
 
 	// split "uses" into "repo"@"ref"
 	i := strings.IndexRune(uses, '@')
-	if i <= 0 || i == len(uses)-1 {
+	if strings.Count(uses, "@") != 1 {
 		return a, errors.New("invalid uses value")
 	}
 

--- a/internal/gha/parse_test.go
+++ b/internal/gha/parse_test.go
@@ -117,6 +117,18 @@ func TestParseUses(t *testing.T) {
 				want: "invalid uses value",
 			},
 			{
+				in:   "f@o/bar@baz",
+				want: "invalid uses value",
+			},
+			{
+				in:   "foo/b@r@baz",
+				want: "invalid uses value",
+			},
+			{
+				in:   "foo/bar/b@z@ref",
+				want: "invalid uses value",
+			},
+			{
 				in:   "foo@bar",
 				want: "invalid repository in uses",
 			},
@@ -162,16 +174,20 @@ func TestParseUses(t *testing.T) {
 				return true
 			}
 
-			if len(path) > 0 {
-				path = "/" + path
-			}
-
 			repo := fmt.Sprintf("%s/%s", owner, project)
 			if strings.Count(repo, "/") != 1 {
 				return true
 			}
 
-			uses := fmt.Sprintf("%s%s@%s", repo, path, ref)
+			if len(path) > 0 {
+				repo = fmt.Sprintf("%s/%s", repo, path)
+			}
+
+			if strings.ContainsRune(repo, '@') {
+				return true
+			}
+
+			uses := fmt.Sprintf("%s@%s", repo, ref)
 
 			action, err := parseUses(uses)
 			if err != nil {


### PR DESCRIPTION
## Summary

Improve the internal `parseUses` function to better handle the `@` sign. In particular, only one of `@` is allowed in the `uses:` value. Before, when multiple appeared in the value, it could be parsed incorrectly. Given such values are invalid, an incorrectly parsed value would result in a downstream error.

This problem was detected by a flaky test failure in the `constructive` property test for the `parseUses` function.