### PR TITLE
Add `-offline` verification support

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,6 +32,6 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Audit
       run: go run tasks.go audit

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Build binary
       run: go run tasks.go build
   dogfeed:
@@ -45,7 +45,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Uninitialize ghasum
       run: rm -f .github/workflows/gha.sum
     - name: Run on this repository
@@ -70,7 +70,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Check source code formatting
       run: go run tasks.go format-check
   reproducible:
@@ -91,7 +91,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Check reproducibility
       run: go run tasks.go reproducible
   test:
@@ -112,7 +112,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Run tests
       run: go run tasks.go coverage
   vet:
@@ -133,6 +133,6 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Vet source code
       run: go run tasks.go vet

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3.24.7
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Get release version
       id: version
       shell: bash

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -27,7 +27,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
     - name: Perform Semgrep analysis
       run: semgrep ci --sarif --output semgrep.sarif
       env:

--- a/cmd/ghasum/main.go
+++ b/cmd/ghasum/main.go
@@ -48,6 +48,7 @@ const (
 	flagNameCache   = "cache"
 	flagNameForce   = "force"
 	flagNameNoCache = "no-cache"
+	flagNameOffline = "offline"
 )
 
 var (

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -32,6 +32,7 @@ func cmdVerify(argv []string) error {
 		flags       = flag.NewFlagSet(cmdNameVerify, flag.ContinueOnError)
 		flagCache   = flags.String(flagNameCache, "", "")
 		flagNoCache = flags.Bool(flagNameNoCache, false, "")
+		flagOffline = flags.Bool(flagNameOffline, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -78,6 +79,7 @@ func cmdVerify(argv []string) error {
 		Workflow: workflow,
 		Job:      job,
 		Cache:    c,
+		Offline:  *flagOffline,
 	}
 
 	problems, err := ghasum.Verify(&cfg)
@@ -132,5 +134,8 @@ The available flags are:
         looks up repositories it needs.
         Defaults to a directory named .ghasum in the user's home directory.
     -no-cache
-        Disable the use of the cache. Makes the -cache flag ineffective.`
+        Disable the use of the cache. Makes the -cache flag ineffective.
+    -offline
+        Run without fetching repositories from the internet, verify exclusively
+        against the cache. If the cache is missing an entry it causes an error.`
 }

--- a/internal/ghasum/atoms.go
+++ b/internal/ghasum/atoms.go
@@ -115,6 +115,10 @@ func compute(cfg *Config, actions []gha.GitHubAction, algo checksum.Algo) ([]sum
 
 		actionDir := path.Join(cfg.Cache.Path(), repo.Owner, repo.Project, repo.Ref)
 		if _, err := os.Stat(actionDir); err != nil {
+			if cfg.Offline {
+				return nil, fmt.Errorf("missing %q from cache", actionDir)
+			}
+
 			err := github.Clone(actionDir, &repo)
 			if err != nil {
 				return nil, fmt.Errorf("clone failed: %v", err)

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -51,6 +51,12 @@ type (
 
 		// Cache is the cache that should be used for the operation.
 		Cache cache.Cache
+
+		// Offline sets whether to rely exclusively on the cache or fetch missing
+		// repositories from the internet.
+		//
+		// Only applies to verification.
+		Offline bool
 	}
 
 	// Problem represents an issue detected when verifying ghasum checksums.

--- a/testdata/verify/error.txtar
+++ b/testdata/verify/error.txtar
@@ -41,6 +41,12 @@ stderr 'no such file or directory'
 stderr 'an unexpected error occurred'
 stderr 'job "not-found" not found in workflow ".github/workflows/workflow.yml"'
 
+# Offline cache entry missing
+! exec ghasum verify -cache .cache/ -offline not-cached/
+! stdout 'Ok'
+stderr 'an unexpected error occurred'
+stderr 'missing ".cache/actions/checkout/not-cached" from cache'
+
 -- initialized/.github/workflows/gha.sum --
 version 1
 
@@ -77,6 +83,21 @@ jobs:
     uses: actions/checkout@v4
 -- no-actions/.keep --
 This file exists to create a repo that does not use Github Actions.
+-- not-cached/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@not-cached b5283HfgB+lTEWTnN3iPEmkOQk+7FBHUMOHw3GjR4M4=
+-- not-cached/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@not-cached
 -- uninitialized/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]


### PR DESCRIPTION
Closes #38
Relates to #2, #17, #36

## Summary

Update the `ghasum verify` command to accept the `-offline` flag and, if provided, don't download repositories from the internet and rely on the cache exclusively. If a repository is missing from the cache this causes an error, avoiding a scenario where a missing repository is (silently) not verified against the sumfile.

This flag is also applied in CI to the "Verify action checksums" steps to ensure it verifies the checksums against the actions that will be used rather a downloaded action (that won't be used).