### PR TITLE
Set up an auto-update workflow for `gha.sum` on Pull Requests from Dependabot

### DIFF
--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -4,3 +4,5 @@ actions/checkout@v4.1.2 5uAXl352I8XStCYyGTbGN7KcAaq2TyH8pPYNxivPuJo=
 actions/setup-go@v5.0.0 lSvPPozeojJimtMLZ7cX1J/h8r1i30yGoTYQbst/jA4=
 github/codeql-action@v3.24.7 lzXmzNy+eVIfpHwZCI3wJmpy6U5VGiIPLmDCjet1oVs=
 ncipollo/release-action@v1.14.0 +JAIlT/RB99JgfxlDrAcAdBnaKX4y8hyFWnHc4j7tfM=
+stefanzweifel/git-auto-commit-action@v5.0.0 t2VeG9180CmZ5/cmxvkFkN6iWoWsOjlaJ2V8rp1HDqY=
+tibdex/github-app-token@v2.1.0 ZNSBo6XSE0yxs8IkHEkVtUC9MkEeXTclXpMLl6zAmCs=

--- a/.github/workflows/ghasum.yml
+++ b/.github/workflows/ghasum.yml
@@ -1,0 +1,38 @@
+name: ghasum
+on:
+  push:
+    branches:
+    - dependabot/github_actions/**
+
+permissions: read-all
+
+jobs:
+  update:
+    name: Update gha.sum
+    runs-on: ubuntu-22.04
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write # To push a commit
+    steps:
+    - name: Create automation token
+      uses: tibdex/github-app-token@v2.1.0
+      id: automation-token
+      with:
+        app_id: ${{ secrets.AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.AUTOMATION_APP_KEY }}
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.2
+      with:
+        token: ${{ steps.automation-token.outputs.token }}
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
+    # NOTE: skip "Verify action checksums" because they might not be up-to-date
+    - name: Update gha.sum
+      run: go run ./cmd/ghasum update -force
+    - name: Commit gha.sum
+      uses: stefanzweifel/git-auto-commit-action@v5.0.0
+      with:
+        commit_message: Update ghasum checksums
+        file_pattern: .github/workflows/gha.sum


### PR DESCRIPTION
Relates to #9

## Summary

Create a GitHub Actions workflow that automatically updates the checksums in `gha.sum` for Pull Requests by Dependabot that update a GitHub Action (as identified by `branches: dependabot/github_actions/**`).