### PR TITLE
Correct flaky test for `parseUses`

### DIFF
--- a/internal/gha/parse_test.go
+++ b/internal/gha/parse_test.go
@@ -183,7 +183,7 @@ func TestParseUses(t *testing.T) {
 				repo = fmt.Sprintf("%s/%s", repo, path)
 			}
 
-			if strings.ContainsRune(repo, '@') {
+			if strings.ContainsRune(repo, '@') || strings.ContainsRune(ref, '@') {
 				return true
 			}
 


### PR DESCRIPTION
Relates to #40

## Summary

Fix a flaky test for the `parseUses` function which could fail if the randomly generated `ref` value contained an at sign. This would result in a constructed `uses:` value with multiple at signs, which is not valid (and would thus error unexpectedly).