### PR TITLE
Correct checksum verification for `Semgrep/Semgrep` job

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -27,7 +27,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /__w/_actions -offline "$WORKFLOW:$JOB"
     - name: Perform Semgrep analysis
       run: semgrep ci --sarif --output semgrep.sarif
       env:


### PR DESCRIPTION
Closes #43
Relates to #4

## Summary

Update the "Verify action checksums" step for the "Semgrep" job in the "Semgrep" workflow. The cache location for this job is different from other jobs because it's running in a container (see `container:` directive at the job level).

[A test job run](https://github.com/ericcornelissen/ghasum/actions/runs/8401072190/job/23009070871#step:5:30) for the `semgrep.yml` worklow on this Pull Request shows this approach should work for now.