### PR TITLE
Bump Go from 1.22.1 to 1.22.2

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.1-alpine3.19
+FROM docker.io/golang:1.22.2-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ghasum
 
-go 1.22.1
+go 1.22.2
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #25, [Audit / Vulnerabilities Job #105](https://github.com/ericcornelissen/ghasum/actions/runs/8548355201)

## Summary

Upgrade from Go 1.22.1 to 1.22.2 to receive 1 security-related update that affects this codebase.

The relevant security ID is GO-2024-2687.