### PR TITLE
Basic cache eviction

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,6 +32,6 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Audit
       run: go run tasks.go audit

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Build binary
       run: go run tasks.go build
   dogfeed:
@@ -45,7 +45,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Uninitialize ghasum
       run: rm -f .github/workflows/gha.sum
     - name: Run on this repository
@@ -70,7 +70,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Check source code formatting
       run: go run tasks.go format-check
   reproducible:
@@ -91,7 +91,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Check reproducibility
       run: go run tasks.go reproducible
   test:
@@ -112,7 +112,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Run tests
       run: go run tasks.go coverage
   vet:
@@ -133,6 +133,6 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Vet source code
       run: go run tasks.go vet

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3.24.9
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /home/runner/work/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Get release version
       id: version
       shell: bash

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -27,7 +27,7 @@ jobs:
         WORKFLOW: ${{ github.workflow_ref }}
       run: |
         WORKFLOW=$(echo "$WORKFLOW" | cut -d '@' -f 1 | cut -d '/' -f 3-5)
-        go run ./cmd/ghasum verify -cache /__w/_actions -offline "$WORKFLOW:$JOB"
+        go run ./cmd/ghasum verify -cache /__w/_actions -no-evict -offline "$WORKFLOW:$JOB"
     - name: Perform Semgrep analysis
       run: semgrep ci --sarif --output semgrep.sarif
       env:

--- a/cmd/ghasum/cache.go
+++ b/cmd/ghasum/cache.go
@@ -51,6 +51,8 @@ func cmdCache(argv []string) error {
 	switch command {
 	case "clear":
 		err = c.Clear()
+	case "evict":
+		err = c.Evict()
 	case "path":
 		msg = c.Path()
 	default:
@@ -69,12 +71,14 @@ func helpCache() string {
 	return `usage: ghasum cache [flags] <command>
 
 Utilities for managing the ghasum cache. This cache is where ghasum stores and
-looks up repositories it needs to do its job.
+looks up repositories it needs to do its job. The maximum age of entries in the
+cache is 5 days, after which it will be evicted.
 
 The available commands are:
 
-    clear    Remove all data from the cache.
-    path     Show the path to the cache.
+    clear   Remove all data from the cache.
+    evict   Remove old data from the cache.
+    path    Show the path to the cache.
 
 The available flags are:
 

--- a/cmd/ghasum/main.go
+++ b/cmd/ghasum/main.go
@@ -48,6 +48,7 @@ const (
 	flagNameCache   = "cache"
 	flagNameForce   = "force"
 	flagNameNoCache = "no-cache"
+	flagNameNoEvict = "no-evict"
 	flagNameOffline = "offline"
 )
 

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -27,9 +27,10 @@ import (
 func cmdUpdate(argv []string) error {
 	var (
 		flags       = flag.NewFlagSet(cmdNameUpdate, flag.ContinueOnError)
-		flagForce   = flags.Bool(flagNameForce, false, "")
 		flagCache   = flags.String(flagNameCache, "", "")
+		flagForce   = flags.Bool(flagNameForce, false, "")
 		flagNoCache = flags.Bool(flagNameNoCache, false, "")
+		flagNoEvict = flags.Bool(flagNameNoEvict, false, "")
 	)
 
 	flags.Usage = func() { fmt.Fprintln(os.Stderr) }
@@ -54,6 +55,12 @@ func cmdUpdate(argv []string) error {
 	c, err := cache.New(*flagCache, *flagNoCache)
 	if err != nil {
 		return errors.Join(errCache, err)
+	}
+
+	if !*flagNoEvict {
+		if err := c.Evict(); err != nil {
+			return errors.Join(errUnexpected, err)
+		}
 	}
 
 	cfg := ghasum.Config{
@@ -88,5 +95,7 @@ The available flags are:
         Force updating the gha.sum file, ignoring errors and fixing them in the
         process.
     -no-cache
-        Disable the use of the cache. Makes the -cache flag ineffective.`
+        Disable the use of the cache. Makes the -cache flag ineffective.
+    -no-evict
+        Disable cache eviction.`
 }

--- a/cmd/ghasum/verify.go
+++ b/cmd/ghasum/verify.go
@@ -32,6 +32,7 @@ func cmdVerify(argv []string) error {
 		flags       = flag.NewFlagSet(cmdNameVerify, flag.ContinueOnError)
 		flagCache   = flags.String(flagNameCache, "", "")
 		flagNoCache = flags.Bool(flagNameNoCache, false, "")
+		flagNoEvict = flags.Bool(flagNameNoEvict, false, "")
 		flagOffline = flags.Bool(flagNameOffline, false, "")
 	)
 
@@ -71,6 +72,12 @@ func cmdVerify(argv []string) error {
 	c, err := cache.New(*flagCache, *flagNoCache)
 	if err != nil {
 		return errors.Join(errCache, err)
+	}
+
+	if !*flagNoEvict {
+		if evictErr := c.Evict(); evictErr != nil {
+			return errors.Join(errUnexpected, evictErr)
+		}
 	}
 
 	cfg := ghasum.Config{
@@ -135,6 +142,8 @@ The available flags are:
         Defaults to a directory named .ghasum in the user's home directory.
     -no-cache
         Disable the use of the cache. Makes the -cache flag ineffective.
+    -no-evict
+        Disable cache eviction.
     -offline
         Run without fetching repositories from the internet, verify exclusively
         against the cache. If the cache is missing an entry it causes an error.`


### PR DESCRIPTION
Closes #3

## Verify

Add a simple and basic cache eviction strategy in order to avoid growing the cache indefinitely and to avoid validating against cache entries indefinitely (which may lead to false negatives). The current eviction strategy is to remove anything older than 5 days.

Cache eviction happens in three scenarios. It happens when updating or verifying (unless the `-no-evict` flag is used), or explicitly using `ghasum cache evict`.

This implementation slightly extends the stated use case in #3 ("keeping the cache at a reasonable size"). The implementation here also considers the scenario where a cached entry prevents proper validation because the remote has been updated.