### PR TITLE
Bump Go from 1.22.2 to 1.22.3

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.2-alpine3.19
+FROM docker.io/golang:1.22.3-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ghasum
 
-go 1.22.2
+go 1.22.3
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #51, [Audit / Vulnerabilities Job #170](https://github.com/ericcornelissen/ghasum/actions/runs/9011440902/job/24759060472)

## Summary

Upgrade from Go 1.22.1 to 1.22.2 to receive 1 security-related update for the standard library that affect this codebase.

The relevant security ID is `GO-2024-2824`.