### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   vulnerabilities:
     name: Vulnerabilities
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.2
@@ -29,7 +29,7 @@ jobs:
       run: go run tasks.go build
   dogfeed:
     name: Dogfeed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - test
     steps:
@@ -54,7 +54,7 @@ jobs:
         go run ./cmd/ghasum verify
   format:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -75,7 +75,7 @@ jobs:
       run: go run tasks.go format-check
   reproducible:
     name: Reproducible build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -96,7 +96,7 @@ jobs:
       run: go run tasks.go reproducible
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -117,7 +117,7 @@ jobs:
       run: go run tasks.go coverage
   vet:
     name: Vet
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   go:
     name: Go
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write # To upload CodeQL results
     steps:

--- a/.github/workflows/ghasum.yml
+++ b/.github/workflows/ghasum.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   update:
     name: Update gha.sum
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write # To push a commit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   github-release:
     name: GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To create a GitHub Release
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   semgrep:
     name: Semgrep
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write # To upload SARIF results
     container:


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. **NOTE:** As of writing this runner is still in beta, so this should not be merged.