### PR TITLE
Bump Go from 1.22.3 to 1.22.4

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.3-alpine3.19
+FROM docker.io/golang:1.22.4-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ghasum
 
-go 1.22.3
+go 1.22.4
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #73, [Audit / Vulnerabilities Job #211](https://github.com/ericcornelissen/ghasum/actions/runs/9377237424/job/25818476367)

## Summary

Upgrade from Go 1.22.3 to 1.22.4 to receive 1 security-related update for the standard library that affect this codebase.

The relevant security ID is `GO-2024-2887`.