### PR TITLE
Make `ghasum update` preserve existing checksums

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -48,10 +48,11 @@ before and releases the lock. In short, updating will only add new and remove
 old checksums from an existing sumfile.
 
 With the `-force` flag the process will ignore errors in the sumfile and fix
-those while updating. If the sumfile version can still be determined from
-sumfile it will be used, otherwise the latest available version is used instead.
-This option is disabled by default to avoid unknowingly fixing syntax errors in
-a sumfile, which is an important fact to know about from a security perspective.
+those while updating. It will also update existing checksums that are incorrect.
+If the sumfile version can still be determined from sumfile it will be used,
+otherwise the latest available version is used instead. This option is disabled
+by default to avoid unknowingly fixing syntax or other errors in a sumfile,
+which is an important fact to know about from a security perspective.
 
 This process does not verify any of the checksums currently in the sumfile.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -38,11 +38,14 @@ by another process leading to an inconsistent state).
 If the file lock is obtained, the process shall first read it and parse it
 completely to extract the sumfile version. If this fails the process shall exit
 immediately unless the `-force` flag is used (see details below). Else it shall
-recompute checksums for all actions used in the repository (see [Computing
-Checksums]) using the best available hashing algorithm. It shall then store them
-in a sumfile (see [Storing Checksums]) using the same sumfile version as before
-and releases the lock. As a consequence, this adds missing and removes redundant
-checksums from the sumfile.
+compute checksums for all new actions used in the repository (see [Computing
+Checksums]) using the best available hashing algorithm. Here, a new action also
+includes a new version of a previously used action. Additionally, it should
+remove any entry which is no longer in use. No existing checksum for a used
+action shall be updated unless the `-force` flag is used. It shall then store
+them in a sumfile (see [Storing Checksums]) using the same sumfile version as
+before and releases the lock. In short, updating will only add new and remove
+old checksums from an existing sumfile.
 
 With the `-force` flag the process will ignore errors in the sumfile and fix
 those while updating. If the sumfile version can still be determined from

--- a/cmd/ghasum/update.go
+++ b/cmd/ghasum/update.go
@@ -92,8 +92,8 @@ The available flags are:
         looks up repositories it needs.
         Defaults to a directory named .ghasum in the user's home directory.
     -force
-        Force updating the gha.sum file, ignoring errors and fixing them in the
-        process.
+        Force updating the gha.sum file, ignoring syntax errors and fixing them
+        in the process. This also fixes any existing checksums that are wrong.
     -no-cache
         Disable the use of the cache. Makes the -cache flag ineffective.
     -no-evict

--- a/internal/ghasum/operations.go
+++ b/internal/ghasum/operations.go
@@ -145,11 +145,13 @@ func Update(cfg *Config, force bool) error {
 		return err
 	}
 
-	for i, entry := range checksums {
-		for _, oldEntry := range oldChecksums {
-			if slices.Equal(entry.ID, oldEntry.ID) {
-				checksums[i] = oldEntry
-				break
+	if !force {
+		for i, entry := range checksums {
+			for _, oldEntry := range oldChecksums {
+				if slices.Equal(entry.ID, oldEntry.ID) {
+					checksums[i] = oldEntry
+					break
+				}
 			}
 		}
 	}

--- a/testdata/update/force.txtar
+++ b/testdata/update/force.txtar
@@ -34,6 +34,12 @@ stdout 'Ok'
 ! stderr .
 cmp no-version/.github/workflows/gha.sum .want/gha.sum
 
+# Invalid existing sum
+exec ghasum update -cache .cache/ -force invalid-sum/
+stdout 'Ok'
+! stderr .
+cmp invalid-sum/.github/workflows/gha.sum .want/gha.sum
+
 -- duplicate/.github/workflows/gha.sum --
 version 1
 
@@ -115,6 +121,21 @@ version-header-missing 1
 
 actions/checkout@v4.1.0 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
 -- no-version/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+-- invalid-sum/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@v4.1.1 GGAV+/JnlPt41B9iINyvcX5z6a4ue+NblmwiDNVORz0=
+-- invalid-sum/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
 

--- a/testdata/update/success.txtar
+++ b/testdata/update/success.txtar
@@ -14,10 +14,32 @@ stdout 'Ok'
 ! stderr .
 cmp changed/.github/workflows/gha.sum want/gha.sum
 
+# Removal necessary
+! cmp remove/.github/workflows/gha.sum want/gha.sum
+
+exec ghasum update -cache .cache/ remove/
+stdout 'Ok'
+! stderr .
+cmp remove/.github/workflows/gha.sum want/gha.sum
+
+# Preserve existing values
+! cmp preserve/.github/workflows/gha.sum want/gha-preserve.sum
+
+exec ghasum update -cache .cache/ preserve/
+stdout 'Ok'
+! stderr .
+cmp preserve/.github/workflows/gha.sum want/gha-preserve.sum
+
 -- want/gha.sum --
 version 1
 
 actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
+actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
+golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+-- want/gha-preserve.sum --
+version 1
+
+actions/checkout@v4.1.1 this-is-invalid-but-should-not-be-updated
 actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
 golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
 -- unchanged/.github/workflows/gha.sum --
@@ -52,6 +74,57 @@ actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
 actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
 golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
 -- changed/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@3a91952
+    - name: This step does not use an action
+      run: Echo 'hello world!'
+-- remove/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@main PKruFKnotZi8RQ196H3R7c5bgw9+mfI7BN/h0A7XiV8=
+actions/checkout@v4.1.1 KsR9XQGH7ydTl01vlD8pIZrXhkzXyjcnzhmP+/KaJZI=
+actions/setup-go@v5.0.0 7lPZupz84sSI3T+PiaMr/ML3XPqJaEo7dMaPsQUnM6c=
+golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+-- remove/.github/workflows/workflow.yml --
+name: Example workflow
+on: [push]
+
+jobs:
+  example:
+    name: example
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.1
+    - name: Install Go
+      uses: actions/setup-go@v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@3a91952
+    - name: This step does not use an action
+      run: Echo 'hello world!'
+-- preserve/.github/workflows/gha.sum --
+version 1
+
+actions/checkout@v4.1.1 this-is-invalid-but-should-not-be-updated
+actions/setup-go@v4.1.0 RQ197c5MRKiujfm0VpQ19p7BN/07XFW9H3R7GH36RXi=
+golangci/golangci-lint-action@3a91952 CVRgC7gGqkOiujfm0VMRKppg/Ztv8FW9GYmyJzcwlCI=
+-- preserve/.github/workflows/workflow.yml --
 name: Example workflow
 on: [push]
 


### PR DESCRIPTION
Closes #8 

## Summary

Update the `ghasum update` command to preserve existing sums even if they're invalid. Here, "existing sums" refers to entries in the sumfile for which the whole ID matches before and after the update. This helps avoid a scenario where an update silently hides that an existing dependent action actually changed while it should not have.