### PR TITLE
Upgrade to Go 1.23.0

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.5-alpine3.19
+FROM docker.io/golang:1.23.0-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ghasum
 
-go 1.22.5
+go 1.23.0
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #92

## Summary

Upgrade from Go 1.22.5 to 1.23.0 to stay up-to-date with the Go language. This update does not include any changes that make sense to be adopted immediately.